### PR TITLE
Implement get_users of NotificationModelMixin

### DIFF
--- a/df_notifications/models.py
+++ b/df_notifications/models.py
@@ -212,7 +212,10 @@ class NotificationModelMixin(models.Model):
     context = models.JSONField(default=dict, blank=True)
 
     def get_users(self, instance: M):
-        return []
+        users = set()
+        for history in instance.history.all():
+            users |= set(history.users.all())
+        return list(users)
 
     def get_context(self, instance: M) -> Dict[str, Any]:
         return {


### PR DESCRIPTION
In this implementation, Firstly create an empty set to store the unique users, and then loop through each related `NotificationHistory` object that the given `instance`. For each `history` object, use the `users` attribute to access the related `User` objects and add them to the `users` set using the `|=` (set union) operator. Finally, convert the `users` set to a list and return it.