### PR TITLE
Added code coverage report for unit tests

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,2 @@
+[run]
+omit = tests/test_app/tests.py, */migrations/*

--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,5 @@
 test:
 	pytest
+
+test-cov:
+	pytest --cov df_notifications --cov tests/test_app 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,11 @@ pip install -r requirements.txt
 ### Running tests
 
 ```
+# Without coverage report
 make test
+
+# With coverage report
+make test-cov
 ```
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ pytest
 pytest-django
 django-dbtemplates
 django-otp-twilio
+pytest-cov


### PR DESCRIPTION
Coverage report was not there in unittests
Added the coverage report generation for unittests via the make command
Also updated the README.md file to run the tests with coverage report

![image](https://user-images.githubusercontent.com/79131920/230925213-ff2498cc-12b2-4663-8a8b-563dc947feb2.png)
