### PR TITLE
Fixed the behaviour to load default settings when user does not define

### DIFF
--- a/df_notifications/models.py
+++ b/df_notifications/models.py
@@ -1,5 +1,6 @@
 from datetime import timedelta
 from df_notifications.fields import NoMigrationsChoicesField
+from df_notifications.settings import api_settings
 from django.conf import settings
 from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.fields import GenericRelation
@@ -99,7 +100,7 @@ class NotificationHistory(models.Model):
     created = models.DateTimeField(auto_now_add=True, db_index=True)
     channel = NoMigrationsChoicesField(
         max_length=255,
-        choices=[(key, key) for key in settings.DF_NOTIFICATIONS["CHANNELS"]],
+        choices=[(key, key) for key in api_settings.CHANNELS],
     )
     template_prefix = models.CharField(max_length=255)
     content = models.JSONField(default=dict, blank=True)
@@ -206,7 +207,7 @@ class NotificationModelMixin(models.Model):
     history = models.ManyToManyField(NotificationHistory, blank=True, editable=False)
     channel = NoMigrationsChoicesField(
         max_length=255,
-        choices=[(key, key) for key in settings.DF_NOTIFICATIONS["CHANNELS"]],
+        choices=[(key, key) for key in api_settings.CHANNELS],
     )
     template_prefix = models.CharField(max_length=255)
     context = models.JSONField(default=dict, blank=True)


### PR DESCRIPTION
There was an issue with loading the default settings when user does not define the DF_NOTIFICATIONS in there settings
When I did install this app for another sample django project I got below error
![Screenshot from 2023-04-12 17-14-27](https://user-images.githubusercontent.com/79131920/231451171-1e190361-3c85-4e22-972b-95db76cb4ba9.png)

It should load the default settings if user does not define DF_NOTIFICATIONS 
When we import the api_settings from the df_notifications.settings in models we can achieve this behaviour

because in [settings.py](https://github.com/rishabh27shah/django-df-notifications/blob/d1448dfa7ff02c9f55b84e123135cce7c9a3813b/df_notifications/settings.py#L22) defaults get loaded in api_settings when user does not define them
