### PR TITLE
prefetch related actions of PushActionCategory objects

### DIFF
--- a/df_notifications/drf/viewsets.py
+++ b/df_notifications/drf/viewsets.py
@@ -14,7 +14,7 @@ class UserDeviceViewSet(FCMDeviceAuthorizedViewSet):
 
 
 class PushActionCategoryViewSet(ListModelMixin, GenericViewSet):
-    queryset = PushActionCategory.objects.filter(is_active=True)
+    queryset = PushActionCategory.objects.prefetch_related("actions").filter(is_active=True)
     permission_classes = (permissions.AllowAny,)
     serializer_class = PushActionCategorySerializer
     pagination_class = None


### PR DESCRIPTION
Updated queryset for `PushActionCategoryViewSet` to avoid multiple database trips of retrieving related `actions`

@eugapx 